### PR TITLE
Add CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+
+defaults: &defaults
+  docker:
+    - image: canonicalwebteam/dev
+
+jobs:
+  nginx-lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install gixy
+          command: pip3 install gixy
+      - run:
+          name: Lint nginx configuration files
+          command: yarn lint-nginx
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - nginx-lint

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "scripts": {
+    "lint-nginx": "gixy nginx.conf",
     "build": "bundle exec jekyll build",
     "serve": "bundle exec jekyll serve -P ${PORT} -H 0.0.0.0",
     "clean": "rm -rf node_modules yarn-error.log css css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle"


### PR DESCRIPTION
## Done

Add CircleCI workflow to the project. Steps added are:
- Nginx configuration file analysis.

## QA
Check the CI wokrflow under my CircleCI space.

OR

- Fork microk8s.io.
- Add this feature branch to your fork.
- Enable project in your own CircleCI space.
- Follow the steps in https://circleci.com/docs/2.0/examples/#section=configuration to trigger a build.
- Check the workflow ran properly.

## Issue / Card
Fixes https://github.com/ubuntudesign/base-squad/issues/202