### PR TITLE
Simplifies installation text

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@ layout: base
     <section class="p-strip is-bordered" id="quick-start">
       <div class="row">
         <h2>Quick start</h2>
-        <p>On Ubuntu 16.04 LTS or 18.04 LTS, install the <a href="https://snapcraft.io/microk8s">MicroK8s&nbsp;snap:</a></p>
+        <p>To install the <a href="https://snapcraft.io/microk8s">MicroK8s&nbsp;snap</a>:</p>
       </div>
       <div class="row u-equal-height">
         <div class="col-8">
@@ -165,8 +165,7 @@ layout: base
             <input class="p-code-snippet__input" aria-label="sudo snap install microk8s --classic" value="sudo snap install microk8s --classic" readonly="readonly">
             <button class="p-code-snippet__action">Copy to clipboard</button>
           </div>
-          <p>To install on other distributions use the <a href="https://snapcraft.io/docs/core/install" class="p-link--external">snapcraft
-              docs.</a></p>
+          <p>Don’t have the <code>snap</code> command? <a href="https://snapcraft.io/docs/core/install" class="p-link--external">Install <code>snapd</code> first.</a></p>
         </div>
       </div>
       <div class="row">


### PR DESCRIPTION
- Avoids assuming that a non-Ubuntu user hasn’t previously installed `snapd` for some other snap.
- Avoids using the term “snapcraft”, since you don’t need to use Snapcraft to install anything.