### PR TITLE
Remove the asciinema section on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -246,18 +246,11 @@ layout: base
         </div>
       </div>
     </section>
-    <section class="p-strip is-bordered">
+    <section class="p-strip is-bordered u-hide--small">
       <div class="row">
         <h2>Working with MicroK8s</h2>
         <h4> Or dive right into the <a href="/docs">docs</a></h4>
-        <script src="https://asciinema.org/a/jUPw2icctB5sSv2JW904qWSej.js" id="asciicast-jUPw2icctB5sSv2JW904qWSej"
-          async="" data-player="[object HTMLDivElement]"></script>
-        <div id="asciicast-container-jUPw2icctB5sSv2JW904qWSej" class="asciicast" style="display: block; float: none; overflow: hidden; padding: 0px; margin: 20px 0px;">
-          <iframe src="https://asciinema.org/a/jUPw2icctB5sSv2JW904qWSej/embed?" id="asciicast-iframe-jUPw2icctB5sSv2JW904qWSej"
-            name="asciicast-iframe-jUPw2icctB5sSv2JW904qWSej" allow="fullscreen" style="overflow: hidden; margin: 0px; border: 0px; display: inline-block; width: 1140px; float: none; visibility: visible; height: 931px;"
-            title="A number to steps to get started with MicroK8s">
-          </iframe>
-        </div>
+        <div class="asciinema-container"></div>
       </div>
     </section>
     <footer class="p-footer">
@@ -319,4 +312,19 @@ layout: base
       false
     );
   }
-  </script>
+
+  var asciinemaContainer = document.querySelector('.asciinema-container');
+  var clientWidth = document.documentElement.clientWidth;
+  var asciinemaContent = '<script src="https://asciinema.org/a/jUPw2icctB5sSv2JW904qWSej.js" id="asciicast-jUPw2icctB5sSv2JW904qWSej"'+
+      'async="" data-player="[object HTMLDivElement]"><\/script>'+
+    '<div id="asciicast-container-jUPw2icctB5sSv2JW904qWSej" class="asciicast" style="display: block; float: none; overflow: hidden; padding: 0px; margin: 20px 0px;">'+
+      '<iframe src="https://asciinema.org/a/jUPw2icctB5sSv2JW904qWSej/embed?" id="asciicast-iframe-jUPw2icctB5sSv2JW904qWSej"'+
+        'name="asciicast-iframe-jUPw2icctB5sSv2JW904qWSej" allow="fullscreen" style="overflow: hidden; margin: 0px; border: 0px; display: inline-block; width: 1140px; float: none; visibility: visible; height: 931px;"'+
+        'title="A number to steps to get started with MicroK8s">'+
+      '</iframe>'+
+    '</div>';
+
+  if (clientWidth >= 620 && asciinemaContainer) {
+    asciinemaContainer.innerHTML = asciinemaContent;
+  }
+</script>


### PR DESCRIPTION
## Done
Inject the asciinema assets via JS based on the screen width 

## QA
- Load the demo
- Open you console on the network tab
- Refresh above 640px wide
- Check that the asciinema section at the bottom of the page loads
- Check the network tab shows the asciinema scripts/fonts load (~600kb combined)
- Shrink the screen below 640px and reload
- Check the section is gone
- Check there is no assets loaded in the console reducing the page load to less then a MB

Fixes https://github.com/canonical-websites/microk8s.io/issues/34